### PR TITLE
[MOBILE-1820] Release 11.0.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,8 @@
+# Airship Accengage Cordova Plugin Changelog
+
+## Version 11.0.1 - August 17, 2020
+
+Initial release.
+
+- Updated iOS Accengage module to 13.5.4
+- Update Android Accengage module to 13.3.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-cordova",
-  "version": "1.0.0",
+  "version": "11.0.1",
   "description": "Urban Airship-Accengage Cordova plugin",
   "cordova": {
     "id": "urbanairship-accengage-cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,68 +1,48 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="urbanairship-accengage-cordova"
-        version="1.0.0"
+        version="11.0.1"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
-        
+
     <name>urbanairship-accengage-cordova</name>
     <description>Urban Airship-Accengage Cordova plugin</description>
     <license>Apache 2.0</license>
     <keywords>cordova,urbanairship</keywords>
     <repo>https://github.com/urbanairship/urbanairship-accengage-cordova.git</repo>
-    
+
     <engines>
         <engine name="cordova-android" version=">=4.1.0"/>
         <engine name="cordova-ios" version=">=5.0.1"/>
         <engine name="cordova" version=">=9.0.1"/>
-        <engine name="urbanairship-cordova" version=">=10.1.0" platform="ios|android" scriptSrc=""/>
     </engines>
-    
+
+    <dependency id="urbanairship-cordova" version=">=11.0.1"/>
+
     <!-- ios -->
     <platform name="ios">
-        
+
         <config-file target="*-Info.plist" parent="UACordovaPluginVersion">
-            <string>1.0.0</string>
+            <string>11.0.1</string>
         </config-file>
-        
-        <config-file parent="/*" target="config.xml">
-            <feature name="UAirship">
-                <param name="ios-package" value="UAirshipPlugin" />
-                <param
-                    name="onload"
-                    value="true"/>
-            </feature>
-        </config-file>
-        
-        <!-- Airship library -->
+
+        <!-- Airship Accengage Module -->
         <podspec>
             <config>
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="Airship/Accengage" spec="13.1.0" />
+                <pod name="Airship/Accengage" spec="13.5.4" />
             </pods>
         </podspec>
-        
+
     </platform>
-    
+
     <!-- android -->
     <platform name="android">
-        <config-file parent="/*" target="res/xml/config.xml">
-            <feature name="UAirship">
-                <param name="android-package" value="com.urbanairship.accengage-cordova.UAirshipPlugin"/>
-                <param
-                    name="onload"
-                    value="true"/>
-            </feature>
-        </config-file>
-        <config-file parent="/*" target="AndroidManifest.xml">
-        </config-file>
-        
         <framework
         custom="true"
         src="src/android/build-extras.gradle"
         type="gradleReference"/>
-        
     </platform>
-    
+
 </plugin>

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -18,7 +18,7 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.urbanairship.android:urbanairship-accengage:12.2.0'
+    implementation 'com.urbanairship.android:urbanairship-accengage:13.3.2'
 }
 
 ext.cdvCompileSdkVersion = 29


### PR DESCRIPTION
Luckily this was not published on NPM as is, so there will be no version discontinuity. I've tested locally by modifying the create sample script in the main repo to add this plugin and verifying that it links in the appropriate platform libs. Since there are no workflow scripts we'll probably need to publish this by hand for now, and since these modules have sat neglected for a while I think we'd be best off making follow up tickets to fold them into a yarn workspace solution in the main repo.